### PR TITLE
Fix CSS set parsing

### DIFF
--- a/jsp-to-html-web.html
+++ b/jsp-to-html-web.html
@@ -206,7 +206,8 @@
                 this.directivePattern = /<%@(.+?)%>/gs;
                 this.declarationPattern = /<%!(.+?)%>/gs;
                 this.commentPattern = /<%--(.+?)--%>/gs;
-                this.cssSetPattern = /<c:set\s+var="css_file_names"\s+value="([^"]+)"\s*\/>/g;
+                // <c:set>タグを柔軟に検出するパターン
+                this.cssSetPattern = /<c:set\b[^>]*\/?>(?:<\/c:set>)?/gi;
                 this.linkPattern = /<link[^>]+rel=["']stylesheet["'][^>]*>/gi;
                 this.stylePattern = /<style[^>]*>[\s\S]*?<\/style>/gi;
                 this.extractedCssFiles = [];
@@ -227,7 +228,13 @@
                 
                 const cssMatches = [...htmlContent.matchAll(this.cssSetPattern)];
                 cssMatches.forEach(match => {
-                    match[1].split(',').forEach(file => cssFileSet.add(file.trim()));
+                    const tag = match[0];
+                    if (/var=["']css_file_names["']/i.test(tag)) {
+                        const valueMatch = tag.match(/value=["']([^"']+)["']/i);
+                        if (valueMatch) {
+                            valueMatch[1].split(',').forEach(file => cssFileSet.add(file.trim()));
+                        }
+                    }
                 });
 
                 // コメント内のCSS指定を探す（より柔軟なパターン）

--- a/jsp-to-html.js
+++ b/jsp-to-html.js
@@ -10,7 +10,8 @@ class JSPToHTMLConverter {
     this.directivePattern = /<%@(.+?)%>/gs;
     this.declarationPattern = /<%!(.+?)%>/gs;
     this.commentPattern = /<%--(.+?)--%>/gs;
-    this.cssSetPattern = /<c:set\s+var="css_file_names"\s+value="([^"]+)"\s*\/>/g;
+    // <c:set>タグを柔軟に検出するパターン
+    this.cssSetPattern = /<c:set\b[^>]*\/?>(?:<\/c:set>)?/gi;
     this.linkPattern = /<link[^>]+rel=["']stylesheet["'][^>]*>/gi;
     this.stylePattern = /<style[^>]*>[\s\S]*?<\/style>/gi;
     this.extractedCssFiles = [];
@@ -31,7 +32,13 @@ class JSPToHTMLConverter {
     
     const cssMatches = [...htmlContent.matchAll(this.cssSetPattern)];
     cssMatches.forEach(match => {
-      match[1].split(',').forEach(file => cssFileSet.add(file.trim()));
+      const tag = match[0];
+      if (/var=["']css_file_names["']/i.test(tag)) {
+        const valueMatch = tag.match(/value=["']([^"']+)["']/i);
+        if (valueMatch) {
+          valueMatch[1].split(',').forEach(file => cssFileSet.add(file.trim()));
+        }
+      }
     });
 
     // コメント内のCSS指定を探す


### PR DESCRIPTION
## Summary
- support flexible attribute order for `<c:set>` tags
- update web converter to use flexible CSS set parsing

## Testing
- `node jsp-to-html.js sample-with-css.jsp output_test.html`
- `node jsp-to-html.js sample_test2.jsp sample_test2.html`

------
https://chatgpt.com/codex/tasks/task_e_6844a2336dd88331a10453901e69bfbd